### PR TITLE
Hoofbranch

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ twitch.client.on('chat', function(channel, user, message, self) {
 
 	let params = input.slice(1, input.length + 1);
 
-	if (customs.temp_customs[input[0]] !== undefined){
+	if (customs.temp_customs[input[0]] !== undefined && user.mod){
 		twitch.sendMessage(customs.temp_customs[input[0]]);
 	}
 	else commands.execute(input[0], user, params);

--- a/lib/database.js
+++ b/lib/database.js
@@ -27,10 +27,10 @@ exports.getNudes = function(callback) {
 }
 
 exports.getMyNudes = function(user, callback) {
-	var sqlGetUser = "SELECT username,count FROM nude_counter WHERE username='" + user + "'";
+	var sqlGetUser = "SELECT username,count FROM nude_counter WHERE username= ?";
 	con.getConnection(function(err, connection) {
 		if(err) throw err;
-		connection.query(sqlGetUser, function(err,res) {
+		connection.query(sqlGetUser,[user], function(err,res) {
 			if (err) throw err;
 			callback(res[0].count);
 			connection.release();
@@ -39,10 +39,10 @@ exports.getMyNudes = function(user, callback) {
 }
 
 exports.incNudes = function(user, callback) {
-	var sqlInc = "UPDATE nude_counter SET count = count + 1 WHERE username = '" + user + "'";
+	var sqlInc = "UPDATE nude_counter SET count = count + 1 WHERE username = ?";
 	con.getConnection(function(err, connection) {
 		if(err) throw err;
-		connection.query(sqlInc, function(err, res) {
+		connection.query(sqlInc,[user], function(err, res) {
 			if (err) throw err;
 			if (callback !== undefined) callback();
 			connection.release();
@@ -51,11 +51,11 @@ exports.incNudes = function(user, callback) {
 }
 
 exports.checkUser = function(user, callback) {
-	var sqlCheckUser = "SELECT * FROM nude_counter WHERE username='" + user + "'";
+	var sqlCheckUser = "SELECT * FROM nude_counter WHERE username= ?";
 	userExists = false;
 	con.getConnection(function(err, connection) {
 		if (err) throw err;
-		connection.query(sqlCheckUser, function(err, res) {
+		connection.query(sqlCheckUser,[user], function(err, res) {
 			if (err) throw err;
 			if (res.length === 1) userExists = true;
 			if (callback !== undefined) callback();
@@ -67,10 +67,10 @@ exports.checkUser = function(user, callback) {
 
 exports.createUser = function(user, callback) {
 	if (!userExists){
-		var sqlCreateUser = "INSERT INTO nude_counter VALUES ('" + user + "',0)";
+		var sqlCreateUser = "INSERT INTO nude_counter VALUES (?,0)";
 		con.getConnection(function(err, connection) {
 			if (err) throw err;
-			connection.query(sqlCreateUser, function(err, res) {
+			connection.query(sqlCreateUser,[user], function(err, res) {
 				if (err) throw err;
 				if (callback !== undefined) callback();
 				connection.release();

--- a/lib/modules/casters.js
+++ b/lib/modules/casters.js
@@ -3,19 +3,14 @@ let commands = require('./../commands');
 
 let casters = [];
 
-//Set current casters !setcasters <caster1> <caster2>
-commands.create({
-	name: "setcasters",
-	admin: true,
-	command: function(command) {
-		casters = command.params;
-	}
-});
-
 //display current casters
 commands.create({
 	name: "casters",
 	command: function(command) {
+		if (command.params[0] === "set" && command.who.mod){
+			command.params.shift();
+			casters = command.params;
+		}
 		twitch.sendMessage("Current caster(s): " + casters.join(", "));
 	}
 });

--- a/lib/modules/customs.js
+++ b/lib/modules/customs.js
@@ -13,7 +13,7 @@ commands.create({
 	mod: true,
 	command: function(command) {
 		var key = command.params[0];
-		var value = command.params.slice(1,command.params.length).join(" ");;
+		var value = command.params.slice(1,command.params.length).join(" ");
 		if  (key !== "create" && key !== "remove"){
 			writer.readDictionary(function(dictionary){
 				writer.addPair(dictionary, key, value, function(){
@@ -48,13 +48,14 @@ commands.create({
 	}
 });
 
-commands.create({
-	name: "show",
-	aliases: [],
-	mod: true,
-	command: function(command) {
-		console.log(temp_customs);
-	}
-})
+//commands.create({
+	//name: "show",
+	//aliases: [],
+	//mod: true,
+	//command: function(command) {
+		//var key = command.params[0];
+		//console.log(commands.commands[key].mod);
+	//}
+//})
 
 module.exports.temp_customs = temp_customs;

--- a/lib/modules/poll.js
+++ b/lib/modules/poll.js
@@ -36,42 +36,38 @@ let createOption = function(option) {
 //create a poll with the specified parameters
 commands.create({
 	name: "poll",
-	admin: true,
+	mod: true,
 	command: function(command) {
-		if(command.params.length < 2) return;
-		poll = {};
-		let optionMessage = "";
-		for(let i = 0; i < command.params.length; i++) {
-			let param = command.params[i];
-			createOption(param);
-			optionMessage += "!" + param + " ";
-		}
-		isVoting = true;
-		twitch.sendMessage("Voting has started! Options: " + optionMessage);
-	}
-});
 
-//end poll
-commands.create({
-	name: "endpoll",
-	admin: true,
-	command: function(command) {
-		isVoting = false;
-		for(let option in poll) {
-			commands.remove(option);
+		//!poll end
+		if (command.params[0] === "end" && isVoting){
+			isVoting = false;
+			for(let option in poll) {
+				commands.remove(option);
+				twitch.sendMessage("Poll over! Results coming soon...")
+			}
 		}
-	}
-});
 
-//show poll results
-commands.create({
-	name: "pollresults",
-	admin: true,
-	command: function(command) {
-		let result = "";
-		for(let option in poll) {
-			result += option + ": " + poll[option].votes.length + " votes. ";
+		//!poll results
+		if (command.params[0] === "results"){
+			let result = "";
+			for(let option in poll) {
+				result += option + ": " + poll[option].votes.length + " votes. ";
+			}
+			twitch.sendMessage(result);
 		}
-		twitch.sendMessage(result);
+
+		if (command.params.length < 2) return;
+		if (!isVoting) {
+			poll = {};
+			let optionMessage = "";
+			for(let i = 0; i < command.params.length; i++) {
+				let param = command.params[i];
+				createOption(param);
+				optionMessage += "!" + param + " ";
+			}
+			isVoting = true;
+			twitch.sendMessage("Voting has started! Options: " + optionMessage);
+		}
 	}
 });

--- a/lib/modules/raffle.js
+++ b/lib/modules/raffle.js
@@ -1,47 +1,71 @@
 let twitch = require('./../twitch');
 let commands = require('./../commands');
+let config = require('./../../config/config');
+let admins = config.twitch.admins;
 
-var raffle;
+var raffle = {};
 var raf = false;
+var key;
 
-//startraffle
-commands.create({
-	name: "startraffle",
-	admin: true,
-	command: function() {
-		raffle = [];
-		raf = true;
-		twitch.sendMessage("Raffle is now OPEN! Type !pickme to enter");
+//creates a new entry
+let addEntry = function(username, key) {
+	if(raffle[key] === undefined) return;
+	raffle[key].entries.push(username);
+};
+
+//creates a new keyword for a raffle
+let createKeyword = function(newkey) {
+	raffle[newkey] = {
+		"entries": []
 	}
-});
 
-//endraffle
-commands.create({
-	name: "endraffle",
-	admin: true,
-	command: function() {
-		raf = false;
-		twitch.sendMessage("Raffle is now CLOSED! Stand by for winner");
-	}
-});
-
-//drawraffle
-commands.create({
-	name: "draw",
-	admin: true,
-	command: function() {
-		twitch.sendMessage("The winner is " + raffle[Math.floor(Math.random()*raffle.length)] + "! Congratulations!");
-	}
-});
-
-//user pick command
-commands.create({
-	name: "pickme",
-	command: function(command) {
-		if (raf){
-			if (raffle.indexOf(command.who["display-name"]) === -1){
-				raffle.push(command.who["display-name"]);
+	commands.create({
+		name: newkey,
+		command: function(command) {
+			if (raf){
+				if (raffle[newkey].entries.indexOf(command.who["display-name"]) === -1){
+					addEntry(command.who['display-name'], newkey)
+				}
 			}
+		}
+	});
+
+	commands.create({
+		name: "draw",
+		mod: true,
+		command: function() {
+			var winner = raffle[key].entries[Math.floor(Math.random()*raffle[key].entries.length)]
+			if (winner === undefined){
+				twitch.sendMessage("The winner is nexusbot2!");
+			}
+			else{
+				twitch.sendMessage("The winner is " + winner + "! Congratulations!");
+			}
+		}
+});
+};
+
+//raffle
+commands.create({
+	name: "raffle",
+	mod: true,
+	command: function(command) {
+		if (command.params[0] === "start") {
+			if (command.params[1] !== undefined && commands.commands[command.params[1]] === undefined && !raf){
+				createKeyword(command.params[1]);
+				key = command.params[1];
+				console.log();
+			}
+			else {
+				createKeyword("nexus");
+				key = "nexus"
+			}
+			raf = true;
+			twitch.sendMessage("Raffle is now OPEN! Type !" + key + " to enter");
+		}
+		else if (command.params[0] === "end") {
+			raf = false;
+			twitch.sendMessage("Raffle is now CLOSED! Stand by for winner");
 		}
 	}
 });

--- a/lib/modules/rosters.js
+++ b/lib/modules/rosters.js
@@ -1,45 +1,27 @@
 let twitch = require('./../twitch');
 let commands = require('./../commands');
+let config = require('./../../config/config');
+let admins = config.twitch.admins;
 
 var teamA;
 var teamB;
-
 var rosterA = [];
 var rosterB = [];
-
-//setteams
-commands.create({
-	name: "setteams",
-	admin: true,
-	command: function(command) {
-		var names = command.params.join(" ").split(",");
-		if (names.length === 2){
-			teamA = names[0].trim();
-			teamB = names[1].trim();
-			twitch.sendMessage("Teams set! " + teamA + " v. " + teamB);			
-		}
-	}
-});
 
 //getteams
 commands.create({
 	name: "teams",
-	admin: true,
 	command: function(command) {
+		if (command.params[0] === "set" && command.who.mod){
+			command.params.shift();
+			var names = command.params.join(" ").split("|");
+			if (names.length === 2){
+				teamA = names[0].trim();
+				teamB = names[1].trim();
+			}
+		}
 		if (teamA && teamB){
-			twitch.sendMessage(teamA + " v. " + teamB);
+			twitch.sendMessage(teamA + " vs. " + teamB);
 		}
 	}
 });
-
-/*setrosters
-commands.create({
-	name: "setroster",
-	admin: true,
-	command: function(command) {
-		var names = command.params.join(" ").split(",");
-
-		twitch.sendMessage("Teams set! " + teamA + " v. " + teamB);
-	}
-});
-*/

--- a/lib/modules/signup.js
+++ b/lib/modules/signup.js
@@ -1,11 +1,8 @@
 let twitch = require('./../twitch');
 let commands = require('./../commands');
+let config = require('./../../config/config');
+let admins = config.twitch.admins;
 
-let tourny = false;
-let koth = false;
-
-let lobby;
-let pass;
 let link;
 
 var time = new Date();
@@ -16,12 +13,7 @@ var day = time.getDate();
 commands.create({
 	name: "signup",
 	command: function() {
-		if (tourny) {
-			twitch.sendMessage("Signups are now closed for the " + month + "/" + day + " tournament! " +
-				"Type !signuplist to see all entries");
-		} else {
-			twitch.sendMessage("https://signup.gamingnex.us/");
-		}
+		twitch.sendMessage("Signup here: https://signup.gamingnex.us/");
 	}
 });
 
@@ -29,11 +21,7 @@ commands.create({
 commands.create({
 	name: "join",
 	command: function() {
-		if (koth) {
-			twitch.sendMessage("Signup link for today's KotH: https://goo.gl/forms/tpQrBbptW7HVZfYV2");
-		} else {
-			twitch.sendMessage("https://signup.gamingnex.us/");
-		}
+		twitch.sendMessage("https://signup.gamingnex.us/");
 	}
 });
 
@@ -48,79 +36,15 @@ commands.create({
 //bracket
 commands.create({
 	name: "bracket",
-	command: function() {
-		if (tourny) {
-			if (link !== undefined){
-				twitch.sendMessage("https://nxs.challonge.com/" + link);
-			}
-			else {
-				twitch.sendMessage("!bracket will be online shortly!")
-			}
-			
-		} else {
-			twitch.sendMessage("Signups are still open - !bracket will be online shortly after closing!");
-		}
-	}
-});
-
-//set bracket
-commands.create({
-	name: "setbracket",
 	command: function(command) {
-		if (command.params.length === 1) {
-			link = command.params[0];
-			twitch.sendMessage("Bracket link set to https://nxs.challonge.com/" + link);
-		} else {
-			twitch.sendMessage("Please supply an argument (link)");
+		if (command.params[0] === "set" && command.who.mod){
+			link = command.params[1];;
 		}
-	}
-});
-
-//tourneymode
-commands.create({
-	name: "tournymode",
-	admin: true,
-	command: function(command) {
-		if(command.params < 1) {
-			tourny = !tourny;
-		} else {
-			if (command.params[0] === "on") tourny = true;
-			else if (command.params[0] === "off") tourny = false;
+		if (link !== undefined){
+			twitch.sendMessage("https://nxs.challonge.com/" + link);
 		}
-		let ret;
-		tourny ? ret = "!signup has ended, !bracket will be online shortly." : ret = "!bracket reset !signup restored";
-		twitch.sendMessage(ret);
-	}
-});
-
-//kothmode
-commands.create({
-	name: "kothmode",
-	admin: true,
-	command: function(command) {
-		if(command.params < 1) {
-			koth = !koth;
-		} else {
-			if (command.params[0] === "on") koth = true;
-			else if (command.params[0] === "off") koth = false;
-		}
-		let ret;
-		koth ? ret = "!join to join the KotH queue!" : ret = "KotH has ended, be sure to !join in next time!";
-		twitch.sendMessage(ret);
-	}
-});
-
-//setlobby command
-commands.create({
-	name: "setlobby",
-	admin: true,
-	command: function(command) {
-		if (command.params.length === 2){
-			lobby = command.params[0];
-			pass = command.params[1];
-			twitch.sendMessage("Lobby/Password set! Use !viewer to display info");
-		} else {
-			twitch.sendMessage("Please supply two arguments (lobby, password)")
+		else {
+			twitch.sendMessage("!bracket will be online 15 minutes before the start of the next tournament!")
 		}
 	}
 });

--- a/lib/modules/signup.js
+++ b/lib/modules/signup.js
@@ -44,7 +44,7 @@ commands.create({
 			twitch.sendMessage("https://nxs.challonge.com/" + link);
 		}
 		else {
-			twitch.sendMessage("!bracket will be online 15 minutes before the start of the next tournament!")
+			twitch.sendMessage("!bracket will be online at the start of the tournament!")
 		}
 	}
 });

--- a/lib/modules/website.js
+++ b/lib/modules/website.js
@@ -44,17 +44,17 @@ commands.create({
 commands.create({
 	name: "matcherino",
 	command: function(command) {
-		if (admins.indexOf(command.who["display-name"]) !== -1){
-			if (command.params[0] === "setlink") matchlink = command.params[1];
-			if (command.params[0] === "setcode") matchcode = command.params[1];
+		if (command.who.mod){
+			if (command.params[0] === "set") {
+				link = command.params[1];
+				code = command.params[2];
+			}
 		}
-		if (matchlink !== undefined){
-			if (matchcode !== undefined){
-				twitch.sendMessage("Use coupon code '" + matchcode + "' to donate a FREE dollar to the prize pool for this tournament @ https://matcherino.com/b/tournaments/" + matchlink);
-			}
-			else {
-				twitch.sendMessage("Donate to the prize pool for this tournament @ https://matcherino.com/b/tournaments/" + matchlink);
-			}
+		if (link === undefined || code === undefined){
+			twitch.sendMessage("Please set matcherino link/code!")
+		}
+		else {
+			twitch.sendMessage("Use coupon code '" + code + "' to donate a FREE dollar to the prize pool for this tournament @ https://matcherino.com/b/tournaments/" + link);
 		}
 	}
 });

--- a/lib/twitch.js
+++ b/lib/twitch.js
@@ -31,9 +31,4 @@ Twitch.sendMessage = function(message) {
 	}
 };
 
-Twitch.whisperMessage = function(message) {
-	
-	Twitch.client.whisper("","")
-}
-
 module.exports = Twitch;

--- a/lib/utils/command-library.json
+++ b/lib/utils/command-library.json
@@ -1,1 +1,1 @@
-{}
+{"test1":"this is a test","Whew":"","whew":"lad","fox":"🐂🐂🐂🐂🐂🐂🐂","***":"","<customcommand>":"<output>"}


### PR DESCRIPTION
index.js - only mods can call custom commands
database.js - SQL injection prevention
customs.js - removed !show which prints a list of the current custom commands to the console

discrete setters for several commands have been removed and replaced with logic in the command they apply too. This is advantageous because the setter now calls the command itself once the output has been set, ensuring changes were made successfully. Setter access requires mod privileges.

casters.js - removed !setcasters [args], implemented !casters set <args>
poll.js - !startpoll is now !poll start [options]. ![option] casts a vote for one of the listed options. !endpoll is now !poll end. !pollresults is now !poll results. Currently users can spam votes which i personally consider a feature and not a bug. All commands other than ![option] require mod privileges

raffle.js - !startraffle is now !raffle start <optional_keyword>. default keyword is "nexus" if one is not specified. ![keyword] enters the user into the raffle. !endraffle is now !raffle end. !draw picks a winner randomly and CAN be called before !raffle end. All commands other than ![keyword] require mod privileges.

rosters.js - !teams set [team1] | [team2] sets output for !teams and requires mod privileges

signups.js - tournymode and kothmode are no more (were stupid to begin with). !setbracket is now !bracket set [link] and requires mod privileges.

website.js - !matcherino setlink and !matcherino setcode have been combined into !matcherino set [link] [code] and requires mod privileges.
